### PR TITLE
Изменения согласно заданию спринта №25

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
 <!-- Разрешения   -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="com.example.playlistmaker.App"
@@ -26,6 +29,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Сервисы   -->
+        <service
+            android:name="com.example.playlistmaker.player.service.MusicService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/playlistmaker/player/di/PlayerModule.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/di/PlayerModule.kt
@@ -8,7 +8,7 @@ import org.koin.dsl.module
 
 val playerModule = module {
     viewModel { params ->
-        PlayerViewModel(params.get(), get(), get(), get(), get(), androidApplication())
+        PlayerViewModel(params.get(), get(), get(), get(), androidApplication())
     }
 
     factory { MediaPlayer() }

--- a/app/src/main/java/com/example/playlistmaker/player/domain/models/PlayStatus.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/domain/models/PlayStatus.kt
@@ -1,6 +1,6 @@
 package com.example.playlistmaker.player.domain.models
 
 data class PlayStatus(
-    val currentPosition: String,
-    val isPlaying: Boolean
+    val currentPosition: String = "00:00",
+    val isPlaying: Boolean = false
 )

--- a/app/src/main/java/com/example/playlistmaker/player/service/AudioPlayerControl.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/service/AudioPlayerControl.kt
@@ -1,0 +1,12 @@
+package com.example.playlistmaker.player.service
+
+import com.example.playlistmaker.player.domain.models.PlayStatus
+import kotlinx.coroutines.flow.StateFlow
+
+interface AudioPlayerControl {
+    fun getCurrentPlayStatus(): StateFlow<PlayStatus>
+    fun startPlayer()
+    fun pausePlayer()
+    fun startForeground()
+    fun stopForeground()
+}

--- a/app/src/main/java/com/example/playlistmaker/player/service/MusicService.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/service/MusicService.kt
@@ -1,0 +1,154 @@
+package com.example.playlistmaker.player.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.media.MediaPlayer
+import android.os.Binder
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.example.playlistmaker.R
+import com.example.playlistmaker.player.domain.models.PlayStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+internal class MusicService : Service() {
+
+    private companion object {
+        const val NOTIFICATION_CHANNEL_ID = "music_service_channel"
+        const val SERVICE_NOTIFICATION_ID = 100
+    }
+
+    inner class MusicServiceBinder : Binder() {
+        fun getService(): MusicService = this@MusicService
+    }
+
+    private val _playStatus = MutableStateFlow(PlayStatus("00:00", false))
+    val playStatus = _playStatus.asStateFlow()
+
+    // Переменная для хранения MediaPlayer
+    private var mediaPlayer: MediaPlayer? = null
+
+    private var timerJob: Job? = null
+
+    // Глобальная переменная для хранения ссылки на трек
+    private var songUrl = ""
+
+    private val binder = MusicServiceBinder()
+
+    override fun onBind(intent: Intent?): IBinder {
+        songUrl = intent?.getStringExtra("song_url") ?: ""
+        if (songUrl.isNotEmpty()) {
+            mediaPlayer?.setDataSource(songUrl)
+            mediaPlayer?.prepareAsync()
+            mediaPlayer?.setOnPreparedListener {
+                _playStatus.value = PlayStatus("00:00", false)
+            }
+            mediaPlayer?.setOnCompletionListener {
+                timerJob?.cancel()
+                _playStatus.value = PlayStatus("00:00", false)
+            }
+        }
+        ServiceCompat.startForeground(
+            /* service = */ this,
+            /* id = */ SERVICE_NOTIFICATION_ID,
+            /* notification = */ createServiceNotification(),
+            /* foregroundServiceType = */ ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        )
+
+        return binder
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        mediaPlayer?.stop()
+        mediaPlayer?.setOnPreparedListener(null)
+        mediaPlayer?.setOnCompletionListener(null)
+        mediaPlayer?.release()
+        mediaPlayer = null
+        return super.onUnbind(intent)
+    }
+
+    // Инициализация ресурсов
+    override fun onCreate() {
+        super.onCreate()
+        mediaPlayer = MediaPlayer()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+
+        return START_NOT_STICKY
+    }
+
+    fun playbackControl() {
+        if (mediaPlayer?.isPlaying == true) {
+            pausePlayer()
+        } else {
+            startPlayer()
+        }
+    }
+
+    // Запуск воспроизведения
+    private fun startPlayer() {
+        mediaPlayer?.start()
+        _playStatus.value = PlayStatus(getCurrentPlayerPosition(), true)
+        startTimer()
+    }
+
+    // Приостановка воспроизведения
+    private fun pausePlayer() {
+        mediaPlayer?.pause()
+        timerJob?.cancel()
+        _playStatus.value = PlayStatus(getCurrentPlayerPosition(), false)
+    }
+
+    private fun createNotificationChannel() {
+
+        val channel = NotificationChannel(
+            /* id= */ NOTIFICATION_CHANNEL_ID,
+            /* name= */ "Music service",
+            /* importance= */ NotificationManager.IMPORTANCE_DEFAULT
+        )
+        channel.description = "Service for playing music"
+
+        // Регистрируем канал уведомлений
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun createServiceNotification(): Notification {
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("[Playlist Maker]")
+            .setContentText("[Исполнитель - Трек]")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+    }
+
+    private fun startTimer() {
+        timerJob = CoroutineScope(Dispatchers.Default).launch {
+            while (mediaPlayer?.isPlaying == true) {
+                delay(200L)
+                _playStatus.value = PlayStatus(getCurrentPlayerPosition(), true)
+            }
+        }
+    }
+
+    private fun getCurrentPlayerPosition(): String {
+        return SimpleDateFormat("mm:ss", Locale.getDefault()).format(mediaPlayer?.currentPosition) ?: "00:00"
+    }
+
+}

--- a/app/src/main/java/com/example/playlistmaker/player/service/MusicService.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/service/MusicService.kt
@@ -19,101 +19,123 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-internal class MusicService : Service() {
+internal class MusicService : Service(), AudioPlayerControl {
+
+    // region Переменные класса
 
     private companion object {
         const val NOTIFICATION_CHANNEL_ID = "music_service_channel"
         const val SERVICE_NOTIFICATION_ID = 100
+        const val REFRESH_TIMER_PERIOD = 200L
     }
 
+    // Объявляем внутренний класс для передачи экземпляра сервиса
     inner class MusicServiceBinder : Binder() {
         fun getService(): MusicService = this@MusicService
     }
 
-    private val _playStatus = MutableStateFlow(PlayStatus("00:00", false))
-    val playStatus = _playStatus.asStateFlow()
+    // Переменные для передачи статуса проигрывателя через StateFlow
+    private val _playStatus = MutableStateFlow(PlayStatus())
+    private val playStatus = _playStatus.asStateFlow()
 
-    // Переменная для хранения MediaPlayer
+    // Переменная для экземпляра MediaPlayer
     private var mediaPlayer: MediaPlayer? = null
 
+    // Переменная для обновления статуса проигрывателя по таймеру
     private var timerJob: Job? = null
 
-    // Глобальная переменная для хранения ссылки на трек
-    private var songUrl = ""
-
+    // Экземпляр внутреннего класса для передачи экземпляра сервиса
     private val binder = MusicServiceBinder()
 
-    override fun onBind(intent: Intent?): IBinder {
-        songUrl = intent?.getStringExtra("song_url") ?: ""
-        if (songUrl.isNotEmpty()) {
-            mediaPlayer?.setDataSource(songUrl)
-            mediaPlayer?.prepareAsync()
-            mediaPlayer?.setOnPreparedListener {
-                _playStatus.value = PlayStatus("00:00", false)
-            }
-            mediaPlayer?.setOnCompletionListener {
-                timerJob?.cancel()
-                _playStatus.value = PlayStatus("00:00", false)
-            }
-        }
-        ServiceCompat.startForeground(
-            /* service = */ this,
-            /* id = */ SERVICE_NOTIFICATION_ID,
-            /* notification = */ createServiceNotification(),
-            /* foregroundServiceType = */ ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-        )
+    // Переменные для хранения заголовка и текста уведомления
+    private var notificationTitle = ""
+    private var notificationText = ""
 
-        return binder
-    }
+    // endregion
 
-    override fun onUnbind(intent: Intent?): Boolean {
-        mediaPlayer?.stop()
-        mediaPlayer?.setOnPreparedListener(null)
-        mediaPlayer?.setOnCompletionListener(null)
-        mediaPlayer?.release()
-        mediaPlayer = null
-        return super.onUnbind(intent)
-    }
+    // region Переопределяемые функции сервиса
 
-    // Инициализация ресурсов
     override fun onCreate() {
         super.onCreate()
-        mediaPlayer = MediaPlayer()
         createNotificationChannel()
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    // Привязка сервиса
+    override fun onBind(intent: Intent?): IBinder {
 
-        return START_NOT_STICKY
+        // Получаем из интента строки для отображения в уведомлении и создаём уведомление
+        notificationTitle = intent?.getStringExtra("notification_title") ?: ""
+        notificationText = intent?.getStringExtra("notification_text") ?: ""
+
+        // Инициализируем проигрыватель, если получили URL трека
+        val songUrl = intent?.getStringExtra("song_url") ?: ""
+
+        if (songUrl.isNotEmpty()) {
+            initMediaPlayer(songUrl)
+        }
+
+        return binder
+
     }
 
-    fun playbackControl() {
-        if (mediaPlayer?.isPlaying == true) {
-            pausePlayer()
-        } else {
-            startPlayer()
-        }
+    // Отвязывание сервиса
+    override fun onUnbind(intent: Intent?): Boolean {
+        // Останавливаем таймер
+        stopTimer()
+        // Освобождаем проигрыватель
+        releaseMediaPlayer()
+        return super.onUnbind(intent)
+    }
+
+    // endregion
+
+    // region Переопределяемые функции интерфейса AudioPlayerControl
+
+    // Получение текущего статуса воспроизведения
+    override fun getCurrentPlayStatus(): StateFlow<PlayStatus> {
+        return playStatus
     }
 
     // Запуск воспроизведения
-    private fun startPlayer() {
+    override fun startPlayer() {
         mediaPlayer?.start()
         _playStatus.value = PlayStatus(getCurrentPlayerPosition(), true)
         startTimer()
     }
 
     // Приостановка воспроизведения
-    private fun pausePlayer() {
+    override fun pausePlayer() {
         mediaPlayer?.pause()
-        timerJob?.cancel()
         _playStatus.value = PlayStatus(getCurrentPlayerPosition(), false)
+        stopTimer()
     }
 
+    override fun startForeground() {
+        ServiceCompat.startForeground(
+            /* service = */ this,
+            /* id = */ SERVICE_NOTIFICATION_ID,
+            /* notification = */ createServiceNotification(),
+            /* foregroundServiceType = */ ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        )
+    }
+
+    override fun stopForeground() {
+        ServiceCompat.stopForeground(
+            /* service = */ this,
+            /* flags = */ ServiceCompat.STOP_FOREGROUND_REMOVE)
+    }
+
+    // endregion
+
+    // region Приватные функции
+
+    // Создание канала уведомлений
     private fun createNotificationChannel() {
 
         val channel = NotificationChannel(
@@ -128,27 +150,61 @@ internal class MusicService : Service() {
         notificationManager.createNotificationChannel(channel)
     }
 
+    // Создание уведомления для foreground сервиса
     private fun createServiceNotification(): Notification {
         return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("[Playlist Maker]")
-            .setContentText("[Исполнитель - Трек]")
+            .setContentTitle(notificationTitle)
+            .setContentText(notificationText)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .build()
     }
 
+    // Инициализируем проигрыватель
+    private fun initMediaPlayer(songUrl: String) {
+        mediaPlayer = MediaPlayer()
+        mediaPlayer?.setDataSource(songUrl)
+        mediaPlayer?.prepareAsync()
+        mediaPlayer?.setOnPreparedListener {
+            _playStatus.value = PlayStatus()
+        }
+        mediaPlayer?.setOnCompletionListener {
+            stopTimer()
+            stopForeground()
+            _playStatus.value = PlayStatus()
+        }
+    }
+
+    // Освобождаем проигрыватель
+    private fun releaseMediaPlayer() {
+        mediaPlayer?.stop()
+        mediaPlayer?.setOnPreparedListener(null)
+        mediaPlayer?.setOnCompletionListener(null)
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+
+    // Запуск таймера отслеживания времени проигрывания трека
     private fun startTimer() {
         timerJob = CoroutineScope(Dispatchers.Default).launch {
             while (mediaPlayer?.isPlaying == true) {
-                delay(200L)
+                delay(REFRESH_TIMER_PERIOD)
                 _playStatus.value = PlayStatus(getCurrentPlayerPosition(), true)
             }
         }
     }
 
-    private fun getCurrentPlayerPosition(): String {
-        return SimpleDateFormat("mm:ss", Locale.getDefault()).format(mediaPlayer?.currentPosition) ?: "00:00"
+    // Остановка таймера отслеживания времени проигрывания трека
+    private fun stopTimer() {
+        timerJob?.cancel()
     }
+
+    // Получение строки с текущим временем проигрывания трека
+    private fun getCurrentPlayerPosition(): String {
+        return SimpleDateFormat("mm:ss", Locale.getDefault()).format(mediaPlayer?.currentPosition) ?: getString(R.string.zero_duration)
+    }
+
+    // endregion
 
 }

--- a/app/src/main/java/com/example/playlistmaker/player/ui/fragment/PlayerFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/player/ui/fragment/PlayerFragment.kt
@@ -1,6 +1,7 @@
 package com.example.playlistmaker.player.ui.fragment
 
 import android.annotation.SuppressLint
+import android.content.IntentFilter
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -22,6 +24,7 @@ import com.example.playlistmaker.media.ui.fragment.BottomSheetPlaylistsAdapter
 import com.example.playlistmaker.player.domain.models.PlayStatus
 import com.example.playlistmaker.player.domain.models.PlayerState
 import com.example.playlistmaker.player.ui.view_model.PlayerViewModel
+import com.example.playlistmaker.util.LostConnectionBroadcastReceiver
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -45,6 +48,9 @@ class PlayerFragment : Fragment() {
             )
         )
     }
+
+    // Инициализируем BroadcastReceiver для контроля соединения с Интернет
+    private val lostConnectionBroadcastReceiver = LostConnectionBroadcastReceiver()
 
     private var isCreatePlaylistCalled: Boolean = false
 
@@ -286,6 +292,17 @@ class PlayerFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         viewModel.refillPlaylists()
+        // Регистрируем BroadcastReceiver для проверки подключения в случае системного изменения подключения
+        ContextCompat.registerReceiver(requireContext(),
+            lostConnectionBroadcastReceiver,
+            IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"),
+            ContextCompat.RECEIVER_NOT_EXPORTED)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Отменяем регистрацию BroadcastReceiver для проверки подключения в случае системного изменения подключения
+        requireContext().unregisterReceiver(lostConnectionBroadcastReceiver)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/playlistmaker/search/ui/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/fragment/SearchFragment.kt
@@ -1,6 +1,7 @@
 package com.example.playlistmaker.search.ui.fragment
 
 import android.annotation.SuppressLint
+import android.content.IntentFilter
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -9,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.core.bundle.bundleOf
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -19,6 +21,7 @@ import com.example.playlistmaker.player.ui.fragment.PlayerFragment
 import com.example.playlistmaker.search.domain.models.SearchState
 import com.example.playlistmaker.search.domain.models.Track
 import com.example.playlistmaker.search.ui.view_model.SearchViewModel
+import com.example.playlistmaker.util.LostConnectionBroadcastReceiver
 import com.example.playlistmaker.util.debounce
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -28,6 +31,9 @@ class SearchFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var onTrackClickDebounce: (Track) -> Unit
+
+    // Инициализируем BroadcastReceiver для контроля соединения с Интернет
+    private val lostConnectionBroadcastReceiver = LostConnectionBroadcastReceiver()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
@@ -218,6 +224,21 @@ class SearchFragment : Fragment() {
             placeholderButton.isVisible = false
             placeholderMessage.text = errorMessage
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Регистрируем BroadcastReceiver для проверки подключения в случае системного изменения подключения
+        ContextCompat.registerReceiver(requireContext(),
+            lostConnectionBroadcastReceiver,
+            IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"),
+            ContextCompat.RECEIVER_NOT_EXPORTED)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Отменяем регистрацию BroadcastReceiver для проверки подключения в случае системного изменения подключения
+        requireContext().unregisterReceiver(lostConnectionBroadcastReceiver)
     }
 
 }

--- a/app/src/main/java/com/example/playlistmaker/util/LostConnectionBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/playlistmaker/util/LostConnectionBroadcastReceiver.kt
@@ -1,0 +1,33 @@
+package com.example.playlistmaker.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.widget.Toast
+import com.example.playlistmaker.R
+
+class LostConnectionBroadcastReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action == "android.net.conn.CONNECTIVITY_CHANGE") {
+            if (!isConnected(context)) Toast.makeText(context, context?.getString(R.string.check_connection), Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun isConnected(context: Context?): Boolean {
+        val connectivityManager = context?.getSystemService(
+            Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+        if (capabilities != null) {
+            when {
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> return true
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> return true
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> return true
+            }
+        }
+        return false
+    }
+
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -65,4 +65,5 @@
     <string name="save">Сохранить</string>
     <string name="playlist_updated_message">Плейлист %1$s изменен</string>
     <string name="playlist_empty_message">Пока здесь нет треков</string>
+    <string name="cant_start_foreground_service">Невозможно запустить foreground службу!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,5 +71,6 @@
     <string name="save">Save</string>
     <string name="playlist_updated_message">Playlist %1$s has been updated</string>
     <string name="playlist_empty_message">No tracks in playlist so far</string>
+    <string name="cant_start_foreground_service">Can\'t start foreground service!</string>
 
 </resources>


### PR DESCRIPTION
- Добавлен сервис MusicService
- Настроена работа сервиса в качестве bound-сервиса для фрагмента PlayerFragment
- Добавлен и реализован интерфейс для взаимодействия с сервисом из ViewModel фрагмента плеера
- Реализован запуск работы сервиса в качестве foreground службы на время свертывания приложения, пока играет трек. При этом в уведомлении указывается название приложения, исполнитель и название трека
- Объект MediaPlayer полностью перенесен из ViewModel в сервис MusicService
- Реализована передача данных о текущем статусе проигрывания трека через StateFlow
- Добавлены дефолтные значения для полей модели PlayStatus
- Проигрывание трека не останавливается при свертывании приложения, а продолжает играть пока приложение или фрагмент экрана плеера полностью не закрыты